### PR TITLE
Adds Webpack ^2.7.0 as a dep, logs stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,9 +14,11 @@ function plugin(options){
         }
         if(webpackOptions) {
             webpack(webpackOptions, function(err, stats) {
+              var info = stats.toString({ chunkModules: false, colors: true });
               if (err || stats.hasErrors()) {
                 console.error(err);
               }
+              console.log(info);
               done();
             });
         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,11 @@ function plugin(options){
                 console.error(err);
               }
               console.log(info);
+
+              for (var file in files) {
+                files[file].webpackStats = stats
+              };
+
               done();
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/blakeandrewwood/metalsmith-webpack2/issues"
   },
-  "homepage": "https://github.com/blakeandrewwood/metalsmith-webpack2#readme"
+  "homepage": "https://github.com/blakeandrewwood/metalsmith-webpack2#readme",
+  "dependencies": {
+    "webpack": "^2.7.0"
+  }
 }


### PR DESCRIPTION
- When adding the ms plugin to your project, npm install on a ms project will include Webpack v2.
- Log webpack stats to provid more insight when the plugin is run 
- adds webpack stats to metalsmith metadata